### PR TITLE
dired-rsync: read passphrase from the minibuffer

### DIFF
--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -156,7 +156,7 @@ dired-buffer modeline."
       (setq indicator (match-string 0 string)))
     ;; check for prompt
     (when (string-match dired-rsync-passphrase-stall-regex string)
-      (setq err "PROMPT"))
+      (process-send-string proc (concat (read-from-minibuffer string) "\n")))
     ;; update if anything to report
     (when (or err indicator)
       (with-current-buffer (plist-get details ':dired-buffer)

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -156,7 +156,7 @@ dired-buffer modeline."
       (setq indicator (match-string 0 string)))
     ;; check for prompt
     (when (string-match dired-rsync-passphrase-stall-regex string)
-      (process-send-string proc (concat (read-from-minibuffer string) "\n")))
+      (process-send-string proc (concat (read-passwd string) "\n")))
     ;; update if anything to report
     (when (or err indicator)
       (with-current-buffer (plist-get details ':dired-buffer)


### PR DESCRIPTION
Hi,

I'd like to change the handling of passphrase prompts. The proposed change makes it so that each prompt is forwarded to the minibuffer using `read-from-minibuffer` and the passphrase sent back using `process-send-string`.

This makes it much easier to interact with rsync when a passphrase is required — currently I have to do this manually using `eval-expression`.