### PR TITLE
Don’t reinvent Tramp path parsing.

### DIFF
--- a/dired-rsync-ert.el
+++ b/dired-rsync-ert.el
@@ -14,49 +14,17 @@
 
 (require 'dired-rsync)
 
-(ert-deftest dired-rsync-test-extract-host ()
-  "Test the various extractions of host from sources."
-  (should (string-equal "host"
-                        (dired-rsync--extract-host-from-tramp
-                         "/ssh:host:/path/to/file.txt")))
-  (should (string-equal "user@host"
-                        (dired-rsync--extract-host-from-tramp
-                         "/ssh:user@host:/path/to/file.txt")))
-  (should (string-equal "host"
-                        (dired-rsync--extract-host-from-tramp
-                         "/ssh:user@host:/path/to/file.txt" t))))
-
-(ert-deftest dired-rsync-test-extract-user ()
-  "Test the various extractions of user from paths."
-  (should (string-equal "user"
-                        (dired-rsync--extract-user-from-tramp
-                         "/ssh:user@host:/path/to/file.txt"))))
-
-
-(ert-deftest dired-rsync-test-extract-path()
-  "Test the various extractions of the path."
-  (should (string-equal "/path/to/file.txt"
-                        (car (dired-rsync--extract-paths-from-tramp
-                              '("/ssh:host:/path/to/file.txt"
-                                "/ssh:host:/path/to/file2.txt")))))
-  (should (string-equal "/path/to/file2.txt"
-                        (nth 1 (dired-rsync--extract-paths-from-tramp
-                              '("/ssh:host:/path/to/file.txt"
-                                "/ssh:host:/path/to/file2.txt")))))
-  (should (string-equal "/path/to/file.txt"
-                        (car (dired-rsync--extract-paths-from-tramp
-                              '("/ssh:host:/path/to/file.txt")))))
-  (should (string-equal "/path/to/pluralised\\'s.txt"
-                        (car (dired-rsync--extract-paths-from-tramp
-                              '("/ssh:host:/path/to/pluralised's.txt"))))))
-
-
 (ert-deftest dired-rsync-test-remote-remote-cmd ()
   "Test we generate a good remote to remote command."
   (should (string-equal
            "ssh -A -R localhost:50000:host:22 seed 'rsync -az --info=progress2 -e \"ssh -p 50000 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" a b c's user@localhost:/video'"
            (dired-rsync--remote-to-remote-cmd "seed" '("a" "b" "c's") "user"
-                                     "host" "/video"))))
+                                              "host" "/video"))))
+
+(ert-deftest dired-rsync-test-command ()
+  (should (string= "rsync -az --info=progress2 remote.host:\"/a.file\" remote.host:\"/b.file\" /home/user"
+                   (dired-rsync--command '("/ssh:remote.host:/a.file" "/ssh:remote.host:/b.file") "/home/user"))))
+
 
 
 


### PR DESCRIPTION
Tramp has built-in functions to parse its paths, `tramp-dissect-file-name`, and the `with-parsed-tramp-file-name` convenience macro.

This PR:

 - Deletes the various `dired-rsync-extract-*` functions and their tests.
 - Updates `dired-rsync--quote-and-maybe-convert-from-tramp` to use `with-parsed-tramp-file-name`.
 - Refactors `dired-rsync`:
   - Split command building logic out to `dired-rsync--command`, which uses `with-parsed-tramp-file-name`.
     - Write a test for it.
   - Instead of binding symbols that are only used once, inline the expr.
   - Add a space to the end of the `read-file-name` prompt; this matches the style of other Dired prompts.