### PR TITLE
Use tramp user if available in rsync address

### DIFF
--- a/dired-rsync-ert.el
+++ b/dired-rsync-ert.el
@@ -57,6 +57,13 @@
                         (car (dired-rsync--extract-paths-from-tramp
                               '("/ssh:servername|sudo:root@servername:/path/to/file.txt"))))))
 
+(ert-deftest dired-rsync-test-quote-and-maybe-convert-from-tramp ()
+  "Test quote and maybe convert from tramp defun"
+  ;; test against regression of issue #26: missing username in rsync command
+  (should (string-equal "username@192.168.1.1:\"/blat/blot/\""
+                        (dired-rsync--quote-and-maybe-convert-from-tramp "/scp:username@192.168.1.1:/blat/blot/")))
+  (should (string-equal "192.168.1.1:\"/blat/blot/\""
+                        (dired-rsync--quote-and-maybe-convert-from-tramp "/scp:192.168.1.1:/blat/blot/"))))
 
 (ert-deftest dired-rsync-test-remote-remote-cmd ()
   "Test we generate a good remote to remote command."

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -113,7 +113,8 @@ It is run in the context of the failed process buffer."
   "Reformat a tramp FILE-OR-PATH to one usable for rsync."
   (if (tramp-tramp-file-p file-or-path)
       (with-parsed-tramp-file-name file-or-path tfop
-        (format "%s:\"%s\"" tfop-host (shell-quote-argument tfop-localname)))
+        (format "%s%s:\"%s\"" (if tfop-user (format "%s@" tfop-user) "") tfop-host
+                (shell-quote-argument tfop-localname)))
     (shell-quote-argument file-or-path)))
 
 (defun dired-rsync--extract-host-from-tramp (file-or-path &optional split-user)


### PR DESCRIPTION
This fixes #26 which I also ran into today, copying files from localhost to an `/scp:different_user@host` tramp destination.
