### PR TITLE
Add a hook to handle success rsyncs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+v0.7
+   - new customisation hook dired-rsync-success-hook
 v0.6
    - use tramp functions to decompose URIs (fix #22)
    - use username from dired URI if we have it in rsync

--- a/README.org
+++ b/README.org
@@ -40,7 +40,8 @@ From time to time the call to rsync may fail. dired-rsync keeps the
 process buffer around for debugging and reports to the console. You
 can customise ~dired-rsync-failed-hook~ with your own hook function or
 select the more aggressive ~dired-rsync--pop-to-rsync-failed-buf~ to
-pop straight to the buffer.
+pop straight to the buffer. Also you can customise ~dired-rsync-success-hook~
+with your own hook function to provide notification for compleated transfers.
 
 The options ~dired-rsync-command~ and ~dired-rsync-options~ are there
 to modify the call to rsync but a user is unlikely to need to tweak

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -87,6 +87,11 @@ It is run in the context of the failed process buffer."
   :type 'hook
   :group 'dired-rsync)
 
+(defcustom dired-rsync-success-hook nil
+  "Hook run when rsync success."
+  :type 'hook
+  :group 'dired-rsync)
+
 ;; Internal variables
 (defvar dired-rsync-proc-buffer-prefix "*rsync"
   "Prefix for process buffers.")
@@ -218,7 +223,8 @@ This gets called whenever the inferior `PROC' changes state as
                    (buffer-live-p dired-buf))
           (with-current-buffer dired-buf
             (dired-unmark-all-marks)))
-        (kill-buffer proc-buf)))
+        (kill-buffer proc-buf))
+      (run-hooks 'dired-rsync-success-hook))
     (dired-rsync--update-modeline)
     ;; If we still have a process buffer things didn't end well
     (when (and (not (process-live-p proc))


### PR DESCRIPTION
Provides `dired-rsync-success-hook` for successful transfers
notifications. Allows you to use notifications based on the
built-in `notifications` library:

```emacs-lisp
(use-package dired-rsync
  :preface
  (require 'notifications)
  :hook
  (dired-rsync-success . (lambda () (notifications-notify :urgency "Low"
                                                          :title   "Rsync success"
                                                          :body    "Rsync success"))))
```

More examples can be found in the `chronos` and `mu4e-alert` packages.