### PR TITLE
Better file path handling

### DIFF
--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -53,7 +53,7 @@
   :type 'string
   :group 'dired-rsync)
 
-(defcustom dired-rsync-options "-az --info=progress2"
+(defcustom dired-rsync-options "-az --info=progress2 --"
   "The default options for the rsync command."
   :type 'string
   :group 'dired-rsync)
@@ -126,7 +126,7 @@ results of `dired-rsync--get-remote-port'.")
   "Reformat a tramp FILE-OR-PATH to one usable for rsync."
   (if (tramp-tramp-file-p file-or-path)
       (with-parsed-tramp-file-name file-or-path tfop
-        (format "%s%s:\"%s\"" (if tfop-user (format "%s@" tfop-user) "") tfop-host
+        (format "%s%s:%s" (if tfop-user (format "%s@" tfop-user) "") tfop-host
                 (shell-quote-argument tfop-localname)))
     (shell-quote-argument file-or-path)))
 


### PR DESCRIPTION
Fixes some things with file path handling.

1. File paths with spaces or other special characters will already be escaped by `shell-quote-argument`, and enclosing in double quotes messes it up. This has been previously mentioned in #34.
2. Because we are no longer double quoting, filenames with dashes will be interpreted as arguments by some shells. So we add `--` as the last option in `dired-rsync-options` to prevent this.

_n.b._ - Unrelated to this PR, I'd suggest changing dired-rsync to use `make-process` (see https://www.gnu.org/software/emacs/manual/html_node/elisp/Asynchronous-Processes.html) to run rsync directly without dependence on the current shell. I see lots of people reporting shell-related things in the issues section, most of which can likely be mitigated by switching to `make-process`, which should work in a consistent way across all systems emacs supports.