### PR TITLE
dired-rsync: clean up process buffer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,8 @@
 v0.7
+   - truncate process buffer output to last status line
+   - raise minimum Emacs version to 25.1
+   - new dired-rsync-transient frontend
+   - various code clean-ups
    - new customisation hook dired-rsync-success-hook
 v0.6
    - use tramp functions to decompose URIs (fix #22)

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -262,8 +262,13 @@ information and update the dired-rsync-modeline-status."
             ;; Insert the text, advancing the process marker.
             (goto-char old-process-mark)
             (insert string)
-            (set-marker (process-mark proc) (point)))
-          (if moving (goto-char (process-mark proc))))))))
+            (set-marker (process-mark proc) (point))
+            ;; Delete old text upto the newline
+            (goto-char (point-max))
+            (when (search-backward "\r")
+              (delete-region (point-min) (+ 1 (match-beginning 0)))))
+          (if moving
+              (goto-char (process-mark proc))))))))
 
 
 (defun dired-rsync--do-run (command details)
@@ -279,9 +284,7 @@ information and update the dired-rsync-modeline-status."
 		       :sentinel (lambda (proc desc)
 				   (dired-rsync--sentinel proc desc details))
 		       :filter (lambda (proc string)
-				 (dired-rsync--filter proc string)))
-		 (when (eq window-system 'ns)
-		   (list :coding 'mac))))
+				 (dired-rsync--filter proc string)))))
   (dired-rsync--update-modeline))
 
 (defun dired-rsync--remote-to-from-local-cmd (sfiles dest)


### PR DESCRIPTION
rsync is helpfully throwing in newlines for the benefit of the terminal to show progress. There is no real need for us to keep all that historical status data once we have scrapped what we want.

Fixes: #36, #39