### PR TITLE
Mention dired-rsync-modeline-status in Commentary section

### DIFF
--- a/dired-rsync-ert.el
+++ b/dired-rsync-ert.el
@@ -53,8 +53,8 @@
                                 "/ssh:host:/path/to/file2.txt")))))
   (should (string-equal "/path/to/file2.txt"
                         (nth 1 (dired-rsync--extract-paths-from-tramp
-                              '("/ssh:host:/path/to/file.txt"
-                                "/ssh:host:/path/to/file2.txt")))))
+                                '("/ssh:host:/path/to/file.txt"
+                                  "/ssh:host:/path/to/file2.txt")))))
   (should (string-equal "/path/to/file.txt"
                         (car (dired-rsync--extract-paths-from-tramp
                               '("/ssh:host:/path/to/file.txt")))))
@@ -77,7 +77,7 @@
   "Test the remote port handling."
   (should (= 50000 (dired-rsync--get-remote-port)))
   (cl-letf (((symbol-function 'dired-rsync--get-active-buffers) (lambda() '(1 2))))
-   (should (= 50002 (dired-rsync--get-remote-port)))))
+    (should (= 50002 (dired-rsync--get-remote-port)))))
 
 (ert-deftest dired-rsync-test-remote-remote-cmd ()
   "Test we generate a good remote to remote command."
@@ -91,8 +91,8 @@
                                               "host" "1022" "/video")))
   (cl-letf (((symbol-function 'dired-rsync--get-active-buffers) (lambda() '(1 2))))
     (should (string-equal
-           "ssh -A -R localhost:50002:host:22 seed \"rsync -az --info=progress2 -e \\\"ssh -p 50002 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\\\" -- a b c's user@localhost:/video\""
-           (dired-rsync--remote-to-remote-cmd "seed" nil '("a" "b" "c's") "user"
-                                              "host" nil "/video")))))
+             "ssh -A -R localhost:50002:host:22 seed \"rsync -az --info=progress2 -e \\\"ssh -p 50002 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\\\" -- a b c's user@localhost:/video\""
+             (dired-rsync--remote-to-remote-cmd "seed" nil '("a" "b" "c's") "user"
+                                                "host" nil "/video")))))
 
 ;;; dired-rsync-ert.el ends here

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -148,7 +148,7 @@ hosts don't need quoting."
   "Extract the username part of a tramp FILE-OR-PATH."
   (with-parsed-tramp-file-name file-or-path tfop
     (or tfop-user
-        ; somehow extract .ssh/config user for tfop-host
+        ;; somehow extract .ssh/config user for tfop-host
         (getenv "USER"))))
 
 (defun dired-rsync--extract-port-from-tramp (file-or-path)
@@ -202,9 +202,8 @@ neither is set we simply display the current number of jobs."
             (format " R:%s" (or ind job-count)))
            ;; Any stale?
            ((dired-rsync--get-proc-buffers)
-            (propertize
-                 " R:hung :-("
-                 'font-lock-face '(:foreground "red")))
+            (propertize " R:hung :-("
+                        'font-lock-face '(:foreground "red")))
            ;; nothing going on
            (t nil)))))
 
@@ -280,17 +279,17 @@ information and update the dired-rsync-modeline-status."
 (defun dired-rsync--do-run (command details)
   "Run rsync COMMAND in a unique buffer, passing DETAILS to sentinel."
   (apply #'make-process
-	 (append (list :name "*rsync*"
-		       :buffer (format "%s @ %s"
-				       dired-rsync-proc-buffer-prefix
-				       (current-time-string))
-		       :command (list shell-file-name
-				      shell-command-switch
-				      command)
-		       :sentinel (lambda (proc desc)
-				   (dired-rsync--sentinel proc desc details))
-		       :filter (lambda (proc string)
-				 (dired-rsync--filter proc string)))))
+         (append (list :name "*rsync*"
+                       :buffer (format "%s @ %s"
+                                       dired-rsync-proc-buffer-prefix
+                                       (current-time-string))
+                       :command (list shell-file-name
+                                      shell-command-switch
+                                      command)
+                       :sentinel (lambda (proc desc)
+                                   (dired-rsync--sentinel proc desc details))
+                       :filter (lambda (proc string)
+                                 (dired-rsync--filter proc string)))))
   (dired-rsync--update-modeline))
 
 (defun dired-rsync--remote-to-from-local-cmd (sfiles dest)
@@ -307,7 +306,7 @@ Fortunately both forms are broadly the same."
             (-flatten
              (list dired-rsync-command
                    dired-rsync-options
-		   (when ssh-port (format "-e 'ssh -p %s'" ssh-port))
+                   (when ssh-port (format "-e 'ssh -p %s'" ssh-port))
                    "--"
                    src-files
                    final-dest)))))

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -37,6 +37,11 @@
 ;; Wherever the files are selected from, the rsync will always run from
 ;; your local machine.
 ;;
+;; To display the progress of a running rsync process in the mode line, you can
+;; use something like the following in your init file:
+;;
+;; (add-to-list 'mode-line-modes
+;;              '(dired-rsync-modeline-status dired-rsync-modeline-status))
 
 (require 'tramp) ; for tramp-tramp-file-p
 (require 'dired-aux) ; for dired-dwim-target-directory

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -195,22 +195,24 @@ neither is set we simply display the current number of jobs."
   (force-mode-line-update)
   (let ((job-count (length (dired-rsync--get-active-buffers))))
     (setq dired-rsync-modeline-status
-          (cond
-           ;; error has occurred
-           (err (propertize
-                 (format " R:%d %s!!" job-count err)
-                 'font-lock-face '(:foreground "red")))
-           ;; we still have jobs but no error
-           ((> job-count 1)
-            (format " R:%d" job-count))
-           ((> job-count 0)
-            (format " R:%s" (or ind job-count)))
-           ;; Any stale?
-           ((dired-rsync--get-proc-buffers)
-            (propertize " R:hung :-("
-                        'font-lock-face '(:foreground "red")))
-           ;; nothing going on
-           (t nil)))))
+          (string-replace
+           "%" "%%"
+           (cond
+            ;; error has occurred
+            (err (propertize
+                  (format " R:%d %s!!" job-count err)
+                  'font-lock-face '(:foreground "red")))
+            ;; we still have jobs but no error
+            ((> job-count 1)
+             (format " R:%d" job-count))
+            ((> job-count 0)
+             (format " R:%s" (or ind job-count)))
+            ;; Any stale?
+            ((dired-rsync--get-proc-buffers)
+             (propertize " R:hung :-("
+                         'font-lock-face '(:foreground "red")))
+            ;; nothing going on
+            (t nil))))))
 
 ;;
 ;; Running rsync: We need to take care of a couple of things here. We

--- a/dired-rsync.el
+++ b/dired-rsync.el
@@ -25,16 +25,16 @@
 ;;
 ;;; Commentary:
 ;;
-;; dired-rsync is a command that can be run from a Dired buffer to
-;; copy files using rsync rather than tramps in-built mechanism.
-;; This is especially useful for copying large files to/from remote
-;; locations without locking up tramp.
+;; `dired-rsync' is a command that can be run from a Dired buffer to
+;; copy files using rsync rather than TRAMP's built-in mechanism.  This
+;; is especially useful for copying large files to/from remote locations
+;; without locking up TRAMP.
 ;;
 ;; To use simply open a Dired buffer, mark some files and invoke
-;; dired-rsync.  After being prompted for a location to copy to an
+;; `dired-rsync'.  After being prompted for a location to copy to, an
 ;; inferior rsync process will be spawned.
 ;;
-;; Wherever the files are selected from the rsync will always run from
+;; Wherever the files are selected from, the rsync will always run from
 ;; your local machine.
 ;;
 


### PR DESCRIPTION
Thank you for this package!

I noticed that this `dired-rsync-modeline-status` variable was very
useful but not really advertised anywhere.  Unlike having a
customization, this was also not as discoverable through the normal
means.

I took the opportunity to also do some unrelated cleanup of
formatting, in separate commits.